### PR TITLE
Use BAM instead of SAM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - conda config --add channels r
   - conda config --add channels bioconda
 install:
-  - conda install --yes numpy scipy pandas scikit-learn
+  - conda install --yes numpy scipy pandas scikit-learn samtools
 script:
   - make -C src allall
   - make -C test

--- a/bowtie2.py
+++ b/bowtie2.py
@@ -103,7 +103,7 @@ class Bowtie2(Aligner):
         # Put all the arguments together
         input_args.extend(aligner_args)
         cmd += ' '
-        cmd += ' '.join(input_args + output_args + index_args)
+        cmd += ' '.join(input_args + index_args + output_args)
         logging.info('Bowtie 2 command: ' + cmd)
         if quiet:
             popen_stderr = open(os.devnull, 'w')

--- a/bowtie2.py
+++ b/bowtie2.py
@@ -18,13 +18,13 @@ except ImportError:
 
 
 class Bowtie2(Aligner):
-    
+
     """ Encapsulates a Bowtie 2 process.  The input can be a FASTQ
         file, or a Queue onto which the caller enqueues reads.
         Similarly, output can be a SAM file, or a Queue from which the
         caller dequeues SAM records.  All records are textual; parsing
         is up to the user. """
-    
+
     def __init__(self,
                  cmd,
                  aligner_args,
@@ -39,17 +39,17 @@ class Bowtie2(Aligner):
                  quiet=False,
                  input_format=None):
         """ Create new process.
-            
+
             Inputs:
-            
+
             'unpaired' is an iterable over unpaired input filenames.
             'paired' is an iterable over pairs of paired-end input
             filenames.  If both are None, then input reads will be
             taken over the inQ.  If either are non-None, then a call
             to inQ will raise an exception.
-            
+
             Outputs:
-            
+
             'sam' is a filename where output SAM records will be
             stored.  If 'sam' is none, SAM records will be added to
             the outQ.
@@ -96,7 +96,7 @@ class Bowtie2(Aligner):
         # Compose output arguments
         output_args = []
         if sam is not None:
-            output_args.extend(['-S', sam])
+            output_args.extend(['| samtools view -Sb - >', sam])
         else:
             raise RuntimeError("Must specify SAM output")
         index_args = ['-x', index]

--- a/bwamem.py
+++ b/bwamem.py
@@ -17,13 +17,13 @@ except ImportError:
 
 
 class BwaMem(Aligner):
-    
+
     """ Encapsulates a BWA-MEM process.  The input can be a FASTQ
         file, or a Queue onto which the caller enqueues reads.
         Similarly, output can be a SAM file, or a Queue from which the
         caller dequeues SAM records.  All records are textual; parsing
         is up to the user. """
-    
+
     def __init__(self,
                  cmd,
                  aligner_args,
@@ -38,17 +38,17 @@ class BwaMem(Aligner):
                  quiet=False,
                  input_format=None):
         """ Create new process.
-            
+
             Inputs:
-            
+
             'unpaired' is an iterable over unpaired input filenames.
             'paired' is an iterable over pairs of paired-end input
             filenames.  If both are None, then input reads will be
             taken over the inQ.  If either are non-None, then a call
             to inQ will raise an exception.
-            
+
             Outputs:
-            
+
             'sam' is a filename where output SAM records will be
             stored.  If 'sam' is none, SAM records will be added to
             the outQ.
@@ -84,7 +84,7 @@ class BwaMem(Aligner):
         # Compose output arguments
         output_args = []
         if sam is not None:
-            output_args.extend(['>', sam])
+            output_args.extend(['| samtools view -Sb - >', sam])
         else:
             raise RuntimeError("Must specify SAM output")
         # Tell bwa mem whether to expected paired-end interleaved input

--- a/hisat2.py
+++ b/hisat2.py
@@ -18,13 +18,13 @@ except ImportError:
 
 
 class Hisat2(Aligner):
-    
+
     """ Encapsulates a HISAT2 process.  The input can be a FASTQ
         file, or a Queue onto which the caller enqueues reads.
         Similarly, output can be a SAM file, or a Queue from which the
         caller dequeues SAM records.  All records are textual; parsing
         is up to the user. """
-    
+
     def __init__(self,
                  cmd,
                  aligner_args,
@@ -39,17 +39,17 @@ class Hisat2(Aligner):
                  quiet=False,
                  input_format=None):
         """ Create new process.
-            
+
             Inputs:
-            
+
             'unpaired' is an iterable over unpaired input filenames.
             'paired' is an iterable over pairs of paired-end input
             filenames.  If both are None, then input reads will be
             taken over the inQ.  If either are non-None, then a call
             to inQ will raise an exception.
-            
+
             Outputs:
-            
+
             'sam' is a filename where output SAM records will be
             stored.  If 'sam' is none, SAM records will be added to
             the outQ.
@@ -96,7 +96,7 @@ class Hisat2(Aligner):
         # Compose output arguments
         output_args = []
         if sam is not None:
-            output_args.extend(['-S', sam])
+            output_args.extend(['| samtools view -Sb - >', sam])
         else:
             raise RuntimeError("Must specify SAM output")
         index_args = ['-x', index]

--- a/qtip
+++ b/qtip
@@ -475,7 +475,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
                 (parse_input_exe, _get_passthrough_args(parse_input_exe), input_sam_fn, ' '.join(args['ref']),
                  pass1_prefix_inp, pass1_prefix_tan)
             logging.info('  running "%s"' % input_parse_cmd)
-            ret = os.system(input_parse_cmd)
+            ret = Popen(input_parse_cmd, shell=True, executable='bash').wait()
             if ret != 0:
                 raise RuntimeError("qtip-parse returned %d" % ret)
             logging.debug('  parsing finished; results in "%s*" and "%s*"' %
@@ -759,7 +759,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
                       (rewrite_exe, _get_passthrough_args(rewrite_exe), input_sam_fn,
                        ' '.join(glob.glob(pred_file_getter.last_prefix + '.*.npy')), final_sam)
                 logging.info('  running "%s"' % cmd)
-                ret = os.system(cmd)
+                ret = Popen(cmd, shell=True, executable='bash').wait()
                 if ret != 0:
                     raise RuntimeError("qtip-rewrite returned %d" % ret)
                 logging.debug('  rewriting finished; results in %s' % final_sam)

--- a/qtip
+++ b/qtip
@@ -236,7 +236,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
     def _get_input_sam_fn():
         """ input.sam goes in the toplevel output directory """
         if args['keep_intermediates']:
-            return join(odir, 'input.sam'), _nop
+            return join(odir, 'input.bam'), _nop
         else:
             dr = temp_man.get_dir('input_alignments')
 
@@ -321,7 +321,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
             if vanilla:
                 return args['vanilla_output']
             else:
-                return join(_compose(_triali, subsamp, incmapq, None), 'final.sam')
+                return join(_compose(_triali, subsamp, incmapq, None), 'final.bam')
 
     class GetTandemSamFile(FileDispenser):
 
@@ -471,7 +471,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
         def _do_parse_input_sam():
             tim.start_timer('Parsing input alignments')
             sanity_check_binary(parse_input_exe)
-            input_parse_cmd = "%s ifs -- %s -- %s -- %s -- %s -- %s" % \
+            input_parse_cmd = "%s ifs -- %s -- <(samtools view %s) -- %s -- %s -- %s" % \
                 (parse_input_exe, _get_passthrough_args(parse_input_exe), input_sam_fn, ' '.join(args['ref']),
                  pass1_prefix_inp, pass1_prefix_tan)
             logging.info('  running "%s"' % input_parse_cmd)
@@ -755,7 +755,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
             def _do_rewrite():
                 tim.start_timer('Rewrite SAM file')
                 sanity_check_binary(rewrite_exe)
-                cmd = "%s %s -- %s -- %s -- %s" % \
+                cmd = "%s %s -- <(samtools view %s) -- %s -- >(samtools view -Sb -o %s -)" % \
                       (rewrite_exe, _get_passthrough_args(rewrite_exe), input_sam_fn,
                        ' '.join(glob.glob(pred_file_getter.last_prefix + '.*.npy')), final_sam)
                 logging.info('  running "%s"' % cmd)

--- a/qtip
+++ b/qtip
@@ -596,11 +596,11 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
             sanity_check_binary(parse_input_exe)
             parse_cmd = "%s f -- %s -- %s -- %s -- %s" % \
                         (parse_input_exe, _get_passthrough_args(parse_input_exe),
-                         ' '.join(map("<(samtools view -h {})".format,
+                         ' '.join(map(<('samtools view -h {})'.format,
                                       filter(_exists_and_nonempty, tandem_sams))),
                          ' '.join(args['ref']), pass2_prefix)
             logging.info('  running "%s"' % parse_cmd)
-            ret = os.system(parse_cmd)
+            ret = Popen(parse_cmd, shell=True, executable='bash').wait()
             if ret != 0:
                 raise RuntimeError("qtip-parse returned %d" % ret)
             logging.debug('  parsing finished; results in "%s.*"' % pass2_prefix)

--- a/qtip
+++ b/qtip
@@ -596,7 +596,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
             sanity_check_binary(parse_input_exe)
             parse_cmd = "%s f -- %s -- %s -- %s -- %s" % \
                         (parse_input_exe, _get_passthrough_args(parse_input_exe),
-                         ' '.join(map(<('samtools view -h {})'.format,
+                         ' '.join(map('<(samtools view -h {})'.format,
                                       filter(_exists_and_nonempty, tandem_sams))),
                          ' '.join(args['ref']), pass2_prefix)
             logging.info('  running "%s"' % parse_cmd)

--- a/qtip
+++ b/qtip
@@ -333,17 +333,17 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
             if args['keep_intermediates']:
                 od = _compose(_triali, None, None, None)
                 mkdir_quiet(od)
-                ret_u_tandsam = join(od, 'tandem_unp.sam')
-                ret_p_tandsam = join(od, 'tandem_paired.sam')
-                ret_b_tandsam = join(od, 'tandem_both.sam')
+                ret_u_tandsam = join(od, 'tandem_unp.bam')
+                ret_p_tandsam = join(od, 'tandem_paired.bam')
+                ret_b_tandsam = join(od, 'tandem_both.bam')
             else:
                 assert self.temp_man is not None
                 if self.temp_dir is None:
                     self.temp_dir = self.temp_man.get_dir('tandem_alignments')
                 pref = _compose(_triali, None, None, None, join_with='_')
-                ret_u_tandsam = join(self.temp_dir, '_'.join([pref, 'tandem_unp.sam']))
-                ret_p_tandsam = join(self.temp_dir, '_'.join([pref, 'tandem_paired.sam']))
-                ret_b_tandsam = join(self.temp_dir, '_'.join([pref, 'tandem_both.sam']))
+                ret_u_tandsam = join(self.temp_dir, '_'.join([pref, 'tandem_unp.bam']))
+                ret_p_tandsam = join(self.temp_dir, '_'.join([pref, 'tandem_paired.bam']))
+                ret_b_tandsam = join(self.temp_dir, '_'.join([pref, 'tandem_both.bam']))
             return ret_u_tandsam, ret_p_tandsam, ret_b_tandsam
 
         def purge(self):
@@ -471,7 +471,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
         def _do_parse_input_sam():
             tim.start_timer('Parsing input alignments')
             sanity_check_binary(parse_input_exe)
-            input_parse_cmd = "%s ifs -- %s -- <(samtools view %s) -- %s -- %s -- %s" % \
+            input_parse_cmd = "%s ifs -- %s -- <(samtools view -h %s) -- %s -- %s -- %s" % \
                 (parse_input_exe, _get_passthrough_args(parse_input_exe), input_sam_fn, ' '.join(args['ref']),
                  pass1_prefix_inp, pass1_prefix_tan)
             logging.info('  running "%s"' % input_parse_cmd)
@@ -596,7 +596,9 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
             sanity_check_binary(parse_input_exe)
             parse_cmd = "%s f -- %s -- %s -- %s -- %s" % \
                         (parse_input_exe, _get_passthrough_args(parse_input_exe),
-                         ' '.join(filter(_exists_and_nonempty, tandem_sams)), ' '.join(args['ref']), pass2_prefix)
+                         ' '.join(map("<(samtools view -h {})".format,
+                                      filter(_exists_and_nonempty, tandem_sams))),
+                         ' '.join(args['ref']), pass2_prefix)
             logging.info('  running "%s"' % parse_cmd)
             ret = os.system(parse_cmd)
             if ret != 0:
@@ -755,7 +757,7 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
             def _do_rewrite():
                 tim.start_timer('Rewrite SAM file')
                 sanity_check_binary(rewrite_exe)
-                cmd = "%s %s -- <(samtools view %s) -- %s -- >(samtools view -Sb -o %s -)" % \
+                cmd = "%s %s -- <(samtools view -h %s) -- %s -- >(samtools view -Sb -o %s -)" % \
                       (rewrite_exe, _get_passthrough_args(rewrite_exe), input_sam_fn,
                        ' '.join(glob.glob(pred_file_getter.last_prefix + '.*.npy')), final_sam)
                 logging.info('  running "%s"' % cmd)

--- a/snap.py
+++ b/snap.py
@@ -53,7 +53,7 @@ except ImportError:
 
 
 class SnapAligner(Aligner):
-    
+
     """ Encapsulates a snap-aligner process.  The input can be a FASTQ
         file, or a Queue onto which the caller enqueues reads.
         Similarly, output can be a SAM file, or a Queue from which the
@@ -84,17 +84,17 @@ class SnapAligner(Aligner):
                  quiet=False,
                  input_format=None):
         """ Create new process.
-            
+
             Inputs:
-            
+
             'unpaired' is an iterable over unpaired input filenames.
             'paired' is an iterable over pairs of paired-end input
             filenames.  If both are None, then input reads will be
             taken over the inQ.  If either are non-None, then a call
             to inQ will raise an exception.
-            
+
             Outputs:
-            
+
             'sam' is a filename where output SAM records will be
             stored.  If 'sam' is none, SAM records will be added to
             the outQ.
@@ -143,7 +143,7 @@ class SnapAligner(Aligner):
             assert tok not in cmd_toks
 
         # Compose output arguments
-        args_output = ['-o', '-sam']
+        args_output = ['-o', '-bam']
         if sam is not None:
             args_output.append(sam)
         else:


### PR DESCRIPTION
This PR uses samtools pipes to store all alignments in BAM instead of SAM. On real data this avoids massive storage issues and should also speed up IO.

This adds two dependencies to qtip:
1. samtools
2. bash

The latter should not be a problem, because it should be available on any current linux and macOS. Samtools will be available for almost everybody who uses qtip. Any samtools and bash version will work.