### PR TITLE
Fix passthrough argument detection: decode output of subcommand before comparing with CLI.

### DIFF
--- a/qtip
+++ b/qtip
@@ -355,10 +355,10 @@ def go(args, aligner_args, aligner_unpaired_args, aligner_paired_args):
     finalsam_file_getter = GetFinalSamFile(temp_man)
 
     def _get_passthrough_args(exe):
-        op = Popen(exe, stdout=PIPE).communicate()[0]
+        op = Popen(exe, stdout=PIPE).communicate()[0].decode()
         ls = []
-        for ar in op.strip().split(b' '):
-            ar_underscore = ar.replace(b'-', b'_')
+        for ar in op.strip().split(' '):
+            ar_underscore = ar.replace('-', '_')
             if ar_underscore in args:
                 logging.debug('  passing through argument "%s"="%s"' % (ar, str(args[ar_underscore])))
                 ls.append(ar)


### PR DESCRIPTION
This should fix issue #6.
The output of the Popen call was raw bytes, while args provides a unicode dict. At least in Python 3, any comparison between unicode and bytes will lead to `False`. Hence, I now decode the output before iterating and comparing.